### PR TITLE
Add filter option

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,11 @@ Use Base64 encoding for SVGs.
 * Required: `false`
 
 Fail on error.
+
+#### filter
+
+* Type: `regex`
+* Default: `/^(background(?:-image)?)|(content)|(cursor)/`
+* Required: `false`
+
+Regex to match the CSS properties to be inlined.

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const DEFAULTS = {
   maxFileSize: 10240,
   b64Svg: false,
   strict: false,
+  filter: /^(background(?:-image)?)|(content)|(cursor)/,
 };
 
 const loop = (cb) => {
@@ -33,7 +34,7 @@ module.exports = postcss.plugin('postcss-image-inliner', (options_ = {}) => {
 
   return async (css) => {
     const urls = new Set([]);
-    const filter = /^(background(?:-image)?)|(content)|(cursor)/;
+    const {filter} = options;
     // Get urls
     css.walkDecls(
       filter,

--- a/test/fixtures/styles/filter.in.css
+++ b/test/fixtures/styles/filter.in.css
@@ -1,0 +1,3 @@
+.filter {
+    border-image: url('../images/blank.gif');
+}

--- a/test/fixtures/styles/filter.out.css
+++ b/test/fixtures/styles/filter.out.css
@@ -1,0 +1,3 @@
+.filter {
+    border-image: url('data:image/gif;base64,R0lGODlhAQABAIAAAAAAAAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==');
+}

--- a/test/test.js
+++ b/test/test.js
@@ -96,4 +96,8 @@ describe('postcss-image-inliner', () => {
   it('should allow globbing', (done) => {
     test('glob.in.css', 'glob.out.css', {assetPaths: 'test/*/images/'}, done);
   });
+
+  it('should consider filter option', (done) => {
+    test('filter.in.css', 'filter.out.css', {filter: /^border-image/}, done);
+  });
 });


### PR DESCRIPTION
Add filter option to specify which CSS properties should be inlined.

Resolves https://github.com/bezoerb/postcss-image-inliner/issues/207